### PR TITLE
add asg config to the self-hosted agent module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "adoagents" {
       name      = "internal"
       primary   = true
       subnet_id = var.subnet_id
+      application_security_group_ids = var.application_security_group_ids
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -59,9 +59,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "adoagents" {
     name    = "NetworkProfile"
     primary = true
     ip_configuration {
-      name      = "internal"
-      primary   = true
-      subnet_id = var.subnet_id
+      name                           = "internal"
+      primary                        = true
+      subnet_id                      = var.subnet_id
       application_security_group_ids = var.application_security_group_ids
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "source_image_reference" {
     version   = "latest"
   }
 }
+
+variable "application_security_group_ids" {
+  type        = list(string)
+  description = "Application Security Groups (ASGs) to associate with the Virtual Machine Scale Set"
+  default     = []
+}


### PR DESCRIPTION
Added application security group property (list of application security groups, default to empty list) and variable to allow adding ASGs to the build agent virtual machine scale sets